### PR TITLE
fix: 非推奨のipcRenderer.removeListenerをipcRenderer.offに置き換え

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "electron-flow",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"description": "A simple utility library with helpful functions",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/format/preload-events.ts
+++ b/src/format/preload-events.ts
@@ -29,7 +29,7 @@ export function formatPreloadEvents(
         };
         ipcRenderer.on("${event.name}", handler);
         return () => {
-            ipcRenderer.removeListener("${event.name}", handler);
+            ipcRenderer.off("${event.name}", handler);
         };
     }`;
 		});

--- a/test/fixture/expected/with-events/preload-events.ts
+++ b/test/fixture/expected/with-events/preload-events.ts
@@ -10,7 +10,7 @@ export default {
         };
         ipcRenderer.on("onError", handler);
         return () => {
-            ipcRenderer.removeListener("onError", handler);
+            ipcRenderer.off("onError", handler);
         };
     },
     onSuccess: (cb: (value: SuccessMessage) => void) => {
@@ -19,7 +19,7 @@ export default {
         };
         ipcRenderer.on("onSuccess", handler);
         return () => {
-            ipcRenderer.removeListener("onSuccess", handler);
+            ipcRenderer.off("onSuccess", handler);
         };
     }
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * バージョンを2.3.1にアップデート
  * IPC listener管理処理の最新化

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->