### PR TITLE
feat(error-handler): エラーハンドラーが生の値を返すように変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [5.0.0] - 2026-01-31
+
+### Changed
+
+- **BREAKING**: エラーハンドラーが生の値を返すように変更
+  - 以前: エラーハンドラーは`Failure<E>`型を返す必要があった
+  - 現在: エラーハンドラーは生の値を返し、フレームワークが`failure()`でラップする
+  - これによりエラーハンドラーの実装がシンプルになる
+- **BREAKING**: renderer側のエラー型が具体的な型に変更
+  - 個別エラーハンドラーあり: `{FuncName}ErrorType | UnknownError`（グローバルありの場合は`| GlobalErrorType`も追加）
+  - グローバルエラーハンドラーのみ: `GlobalErrorType | UnknownError`
+  - エラーハンドラーなし: `UnknownError`
+- エラーハンドラーはtry-catchで囲まれ、ハンドラー自体がエラーを投げた場合は`UnknownError`を返す
+
+### Added
+
+- `UnknownError`型を追加（エラーハンドラーが処理できなかったエラーを表現）
+  - `unknownError(value)`: UnknownError型を生成
+  - `isUnknownError(error)`: UnknownError型かどうかを判定
+- `customErrorHandler.debug`オプションを追加（デフォルト: false）
+- `errorHandlerConfig.debug`オプションを追加（デフォルト: false）
+  - `true`の場合、エラーハンドラーがエラーを投げた時に`console.warn`を出力
+
 ## [4.0.0] - 2026-01-30
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "electron-flow",
-	"version": "4.0.0",
+	"version": "5.0.0",
 	"description": "A simple utility library with helpful functions",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/format/register.ts
+++ b/src/format/register.ts
@@ -94,7 +94,7 @@ export function formatHandlers(
                     }
                     return failure(${customErrorHandler.functionName}(e, { ...ctx, event }));
                 } catch (handlerError) {
-                    ${warnCode}return failure(e);
+                    ${warnCode}return failure(unknownError(e));
                 }`;
 			}
 			// 個別のみ（グローバルなし）
@@ -103,9 +103,9 @@ export function formatHandlers(
                     if (individualResult !== null) {
                         return failure(individualResult);
                     }
-                    return failure(e);
+                    return failure(unknownError(e));
                 } catch (handlerError) {
-                    ${warnCode}return failure(e);
+                    ${warnCode}return failure(unknownError(e));
                 }`;
 		}
 		// グローバルのみまたはどちらもなし
@@ -113,10 +113,10 @@ export function formatHandlers(
 			return `try {
                     return failure(${customErrorHandler.functionName}(e, { ...ctx, event }));
                 } catch (handlerError) {
-                    ${warnCode}return failure(e);
+                    ${warnCode}return failure(unknownError(e));
                 }`;
 		}
-		return `return failure(e);`;
+		return `return failure(unknownError(e));`;
 	};
 
 	const handlerStatements = packageInfos.flatMap((pkg) => {
@@ -203,7 +203,7 @@ export function formatHandlers(
 	);
 	const electronFlowImports =
 		hasHandlers || customErrorHandler || hasIndividualErrorHandler
-			? '\nimport { success, failure } from "electron-flow";'
+			? '\nimport { success, failure, unknownError } from "electron-flow";'
 			: "";
 
 	const text = `// auto generated

--- a/src/format/register.ts
+++ b/src/format/register.ts
@@ -20,6 +20,11 @@ export interface ErrorHandlerConfig {
 	 * @default "{funcName}ErrorHandler"
 	 */
 	pattern?: string;
+	/**
+	 * エラーハンドラーが失敗した場合にconsole.warnを出力するかどうか
+	 * @default false
+	 */
+	debug?: boolean;
 }
 
 export function formatHandlers(
@@ -29,9 +34,10 @@ export function formatHandlers(
 	customErrorHandler?: {
 		path: string;
 		functionName: string;
+		debug?: boolean;
 	},
 	_validatorConfig?: ValidatorConfig,
-	_errorHandlerConfig?: ErrorHandlerConfig,
+	errorHandlerConfig?: ErrorHandlerConfig,
 ) {
 	const importStatements = createImportStatement(
 		outputPath,
@@ -57,6 +63,9 @@ export function formatHandlers(
 		},
 	);
 
+	// debugオプションの決定（customErrorHandlerまたはerrorHandlerConfigのdebugがtrueならtrue）
+	const debug = customErrorHandler?.debug || errorHandlerConfig?.debug || false;
+
 	/**
 	 * エラーハンドリングコードを生成
 	 * 優先順位:
@@ -64,29 +73,50 @@ export function formatHandlers(
 	 *    - nullを返した場合はグローバルへフォールバック
 	 * 2. グローバルエラーハンドラー（customErrorHandler）がある場合
 	 * 3. どちらもなければ failure(e) を返す
+	 *
+	 * すべてのエラーハンドラーはtry-catchで囲み、ハンドラーがエラーを投げた場合はfailure(e)を返す
+	 * カスタムエラーハンドラーは生の値を返すので、failure()でラップする
 	 */
 	const generateErrorHandlerCode = (errorHandlerName?: string): string => {
+		const warnCode = debug
+			? `console.warn("[electron-flow] Error handler threw an error:", handlerError);
+                    `
+			: "";
+
 		if (errorHandlerName) {
 			// 個別エラーハンドラーがある場合
 			if (customErrorHandler) {
 				// 個別 + グローバル両方ある場合
-				return `const individualResult = ${errorHandlerName}(e, { ...ctx, event });
-                if (individualResult !== null) {
-                    return failure(individualResult);
-                }
-                return ${customErrorHandler.functionName}(e, { ...ctx, event });`;
+				return `try {
+                    const individualResult = ${errorHandlerName}(e, { ...ctx, event });
+                    if (individualResult !== null) {
+                        return failure(individualResult);
+                    }
+                    return failure(${customErrorHandler.functionName}(e, { ...ctx, event }));
+                } catch (handlerError) {
+                    ${warnCode}return failure(e);
+                }`;
 			}
 			// 個別のみ（グローバルなし）
-			return `const individualResult = ${errorHandlerName}(e, { ...ctx, event });
-                if (individualResult !== null) {
-                    return failure(individualResult);
-                }
-                return failure(e);`;
+			return `try {
+                    const individualResult = ${errorHandlerName}(e, { ...ctx, event });
+                    if (individualResult !== null) {
+                        return failure(individualResult);
+                    }
+                    return failure(e);
+                } catch (handlerError) {
+                    ${warnCode}return failure(e);
+                }`;
 		}
 		// グローバルのみまたはどちらもなし
-		return customErrorHandler
-			? `return ${customErrorHandler.functionName}(e, { ...ctx, event });`
-			: `return failure(e);`;
+		if (customErrorHandler) {
+			return `try {
+                    return failure(${customErrorHandler.functionName}(e, { ...ctx, event }));
+                } catch (handlerError) {
+                    ${warnCode}return failure(e);
+                }`;
+		}
+		return `return failure(e);`;
 	};
 
 	const handlerStatements = packageInfos.flatMap((pkg) => {

--- a/src/format/renderer.ts
+++ b/src/format/renderer.ts
@@ -63,17 +63,18 @@ export function formatRendererIF(
 			// 個別エラーハンドラーあり
 			const individualType = `${capitalize(func.name)}ErrorType`;
 			if (customErrorHandler) {
-				// 個別 + グローバル → union型
-				return `${individualType} | GlobalErrorType`;
+				// 個別 + グローバル → union型（フォールバック時はUnknownError）
+				return `${individualType} | GlobalErrorType | UnknownError`;
 			}
-			// 個別のみ → union with unknown
-			return `${individualType} | unknown`;
+			// 個別のみ → union with UnknownError
+			return `${individualType} | UnknownError`;
 		}
 		// 個別なし
 		if (customErrorHandler) {
-			return "GlobalErrorType";
+			// グローバルのみ → union with UnknownError（ハンドラーエラー時）
+			return "GlobalErrorType | UnknownError";
 		}
-		return "unknown";
+		return "UnknownError";
 	};
 
 	// インターフェース定義
@@ -135,11 +136,11 @@ export function formatRendererIF(
 			})()
 		: "";
 
-	// Resultのimport（Failureは不要になった）
+	// Resultのimport
 	const resultImport = hasFunctions
 		? unwrapResults
-			? 'import { isFailure, type Result } from "electron-flow/result";'
-			: 'import type { Result } from "electron-flow";'
+			? 'import { isFailure, type Result, type UnknownError } from "electron-flow/result";'
+			: 'import type { Result, UnknownError } from "electron-flow";'
 		: "";
 
 	const apiContent =

--- a/src/format/renderer.ts
+++ b/src/format/renderer.ts
@@ -2,6 +2,9 @@ import { relative } from "node:path";
 import type { PackageInfo } from "../parse/parseFile.js";
 import { createImportStatement } from "./utils.js";
 
+// 先頭を大文字にするヘルパー関数
+const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
+
 export function formatRendererIF(
 	packages: PackageInfo[],
 	outputPath: string,
@@ -11,22 +14,67 @@ export function formatRendererIF(
 		functionName: string;
 	},
 ) {
+	// 個別エラーハンドラーを持つ関数を収集
+	const functionsWithErrorHandler = packages.flatMap((pkg) =>
+		pkg.func
+			.filter((func) => func.errorHandlerName)
+			.map((func) => ({
+				funcName: func.name,
+				errorHandlerName: func.errorHandlerName as string,
+				importPath: pkg.path,
+			})),
+	);
+
 	const importStatements = createImportStatement(
 		outputPath,
 		packages,
-		(functionNames, importPath) => {
-			return `import type { ${functionNames} } from "${importPath}.js";`;
+		(functionNames, importPath, pkg) => {
+			// 個別エラーハンドラー名を収集（このパッケージに含まれるもの）
+			const errorHandlerNames = pkg.func
+				.filter((func) => func.errorHandlerName)
+				.map((func) => func.errorHandlerName as string);
+			const additionalTypeImports = errorHandlerNames.filter(
+				(name, index, self) => self.indexOf(name) === index,
+			);
+			const allImports =
+				additionalTypeImports.length > 0
+					? `${functionNames}, ${additionalTypeImports.join(", ")}`
+					: functionNames;
+			return `import type { ${allImports} } from "${importPath}.js";`;
 		},
 	);
 
 	const functions = packages.flatMap((pkg) => {
 		return pkg.func.map((func) => {
-			return { name: func.name, request: func.request };
+			return {
+				name: func.name,
+				request: func.request,
+				errorHandlerName: func.errorHandlerName,
+			};
 		});
 	});
 
-	// エラー型の決定（customErrorHandlerがあればErrorType、なければunknown）
-	const errorType = customErrorHandler ? "ErrorType" : "unknown";
+	// 関数ごとのエラー型を決定
+	const getErrorTypeForFunction = (func: {
+		name: string;
+		errorHandlerName: string | undefined;
+	}) => {
+		if (func.errorHandlerName) {
+			// 個別エラーハンドラーあり
+			const individualType = `${capitalize(func.name)}ErrorType`;
+			if (customErrorHandler) {
+				// 個別 + グローバル → union型
+				return `${individualType} | GlobalErrorType`;
+			}
+			// 個別のみ → union with unknown
+			return `${individualType} | unknown`;
+		}
+		// 個別なし
+		if (customErrorHandler) {
+			return "GlobalErrorType";
+		}
+		return "unknown";
+	};
 
 	// インターフェース定義
 	const interfaceLines = unwrapResults
@@ -34,11 +82,13 @@ export function formatRendererIF(
 				return `${func.name}: (${func.request.map((line) => `${line.name}: ${line.type}`).join(", ")}) => Promise<ReturnTypeUnwrapped<typeof ${func.name}>>`;
 			})
 		: functions.map((func) => {
+				const errorType = getErrorTypeForFunction(func);
 				return `${func.name}: (${func.request.map((line) => `${line.name}: ${line.type}`).join(", ")}) => Promise<Result<ReturnTypeUnwrapped<typeof ${func.name}>, ${errorType}>>`;
 			});
 
 	// window.api メソッドの型定義
 	const windowApiMethods = functions.map((func) => {
+		const errorType = getErrorTypeForFunction(func);
 		return `${func.name}: (${func.request.map((req) => `${req.name}: ${req.type}`).join(", ")}) => Promise<Result<ReturnTypeUnwrapped<typeof ${func.name}>, ${errorType}>>`;
 	});
 
@@ -85,14 +135,11 @@ export function formatRendererIF(
 			})()
 		: "";
 
+	// Resultのimport（Failureは不要になった）
 	const resultImport = hasFunctions
 		? unwrapResults
-			? customErrorHandler
-				? 'import { isFailure, type Result, type Failure } from "electron-flow/result";'
-				: 'import { isFailure, type Result } from "electron-flow/result";'
-			: customErrorHandler
-				? 'import type { Result, Failure } from "electron-flow";'
-				: 'import type { Result } from "electron-flow";'
+			? 'import { isFailure, type Result } from "electron-flow/result";'
+			: 'import type { Result } from "electron-flow";'
 		: "";
 
 	const apiContent =
@@ -122,16 +169,27 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
 `
 		: "";
 
-	// カスタムエラーハンドラーがある場合のエラー型ユーティリティ
-	const errorTypeUtilities =
+	// グローバルエラー型ユーティリティ（カスタムエラーハンドラーがある場合）
+	const globalErrorTypeUtility =
 		hasFunctions && customErrorHandler
-			? `// Failureからエラー型を抽出する型ユーティリティ
-type ExtractFailureType<T> = T extends Failure<infer E> ? E : unknown;
-type ErrorType = ExtractFailureType<ReturnType<typeof ${customErrorHandler.functionName}>>;
+			? `// グローバルエラーハンドラーの型（生の値を返す）
+type GlobalErrorType = ReturnType<typeof ${customErrorHandler.functionName}>;
 `
 			: "";
 
-	const typeUtilities = baseTypeUtilities + errorTypeUtilities;
+	// 個別エラーハンドラーの型定義（エラーハンドラーを持つ関数ごとに生成）
+	const individualErrorTypeDefinitions =
+		hasFunctions && functionsWithErrorHandler.length > 0
+			? `${functionsWithErrorHandler
+					.map(
+						({ funcName, errorHandlerName }) =>
+							`type ${capitalize(funcName)}ErrorType = NonNullable<ReturnType<typeof ${errorHandlerName}>>;`,
+					)
+					.join("\n")}\n`
+			: "";
+
+	const typeUtilities =
+		baseTypeUtilities + globalErrorTypeUtility + individualErrorTypeDefinitions;
 
 	const interfaceDefinition = hasFunctions
 		? `

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,8 @@ type AutoCodeOption = {
 		path: string;
 		/** エクスポートされた関数名 */
 		functionName: string;
+		/** エラーハンドラーが失敗した場合にconsole.warnを出力するかどうか（デフォルト: false） */
+		debug?: boolean;
 	};
 	/** Result型をアンラップして例外ベースのAPIに変換するか（デフォルト: false） */
 	unwrapResults?: boolean;

--- a/src/result.ts
+++ b/src/result.ts
@@ -29,3 +29,24 @@ export function isFailure<T, E = Error>(
 ): result is Failure<E> {
 	return result._tag === "failure";
 }
+
+/**
+ * エラーハンドラーが処理できなかったエラーをラップする型
+ */
+export type UnknownError = {
+	_tag: "UnknownError";
+	value: unknown;
+};
+
+export function unknownError(value: unknown): UnknownError {
+	return { _tag: "UnknownError", value };
+}
+
+export function isUnknownError(error: unknown): error is UnknownError {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"_tag" in error &&
+		(error as UnknownError)._tag === "UnknownError"
+	);
+}

--- a/test/fixture/001-basic-object-args/expected/register/handlers.ts
+++ b/test/fixture/001-basic-object-args/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { execute } from "../../../fixture/001-basic-object-args/input/apis/sample.js";
 
@@ -12,7 +12,7 @@ export const autoGenerateHandlers = {
                 const result = await execute({ ...ctx, event }, args);
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },

--- a/test/fixture/001-basic-object-args/expected/renderer/api.ts
+++ b/test/fixture/001-basic-object-args/expected/renderer/api.ts
@@ -1,6 +1,6 @@
 // auto generated
 import type { execute } from "../../../fixture/001-basic-object-args/input/apis/sample.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -13,14 +13,14 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
 declare global {
     interface Window {
         api: {
-            execute: (id: string, name: string) => Promise<Result<ReturnTypeUnwrapped<typeof execute>, unknown>>;
+            execute: (id: string, name: string) => Promise<Result<ReturnTypeUnwrapped<typeof execute>, UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    execute: (id: string, name: string) => Promise<Result<ReturnTypeUnwrapped<typeof execute>, unknown>>;
+    execute: (id: string, name: string) => Promise<Result<ReturnTypeUnwrapped<typeof execute>, UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/002-no-args/expected/register/handlers.ts
+++ b/test/fixture/002-no-args/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { ping } from "../../../fixture/002-no-args/input/apis/sample.js";
 
@@ -12,7 +12,7 @@ export const autoGenerateHandlers = {
                 const result = await ping({ ...ctx, event });
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },

--- a/test/fixture/002-no-args/expected/renderer/api.ts
+++ b/test/fixture/002-no-args/expected/renderer/api.ts
@@ -1,6 +1,6 @@
 // auto generated
 import type { ping } from "../../../fixture/002-no-args/input/apis/sample.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -13,14 +13,14 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
 declare global {
     interface Window {
         api: {
-            ping: () => Promise<Result<ReturnTypeUnwrapped<typeof ping>, unknown>>;
+            ping: () => Promise<Result<ReturnTypeUnwrapped<typeof ping>, UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    ping: () => Promise<Result<ReturnTypeUnwrapped<typeof ping>, unknown>>;
+    ping: () => Promise<Result<ReturnTypeUnwrapped<typeof ping>, UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/003-unwrap-results/expected/register/handlers.ts
+++ b/test/fixture/003-unwrap-results/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { getData } from "../../../fixture/003-unwrap-results/input/apis/sample.js";
 
@@ -12,7 +12,7 @@ export const autoGenerateHandlers = {
                 const result = await getData({ ...ctx, event }, args);
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },

--- a/test/fixture/003-unwrap-results/expected/renderer/api.ts
+++ b/test/fixture/003-unwrap-results/expected/renderer/api.ts
@@ -1,6 +1,6 @@
 // auto generated
 import type { getData } from "../../../fixture/003-unwrap-results/input/apis/sample.js";
-import { isFailure, type Result } from "electron-flow/result";
+import { isFailure, type Result, type UnknownError } from "electron-flow/result";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -13,7 +13,7 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
 declare global {
     interface Window {
         api: {
-            getData: (id: string) => Promise<Result<ReturnTypeUnwrapped<typeof getData>, unknown>>;
+            getData: (id: string) => Promise<Result<ReturnTypeUnwrapped<typeof getData>, UnknownError>>;
         };
     }
 }

--- a/test/fixture/004-external-schema/expected/register/handlers.ts
+++ b/test/fixture/004-external-schema/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { getUser } from "../../../fixture/004-external-schema/input/apis/user-api.js";
 
@@ -12,7 +12,7 @@ export const autoGenerateHandlers = {
                 const result = await getUser({ ...ctx, event }, args);
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },

--- a/test/fixture/004-external-schema/expected/renderer/api.ts
+++ b/test/fixture/004-external-schema/expected/renderer/api.ts
@@ -1,6 +1,6 @@
 // auto generated
 import type { getUser } from "../../../fixture/004-external-schema/input/apis/user-api.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -13,14 +13,14 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
 declare global {
     interface Window {
         api: {
-            getUser: (userId: string, email: string) => Promise<Result<ReturnTypeUnwrapped<typeof getUser>, unknown>>;
+            getUser: (userId: string, email: string) => Promise<Result<ReturnTypeUnwrapped<typeof getUser>, UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    getUser: (userId: string, email: string) => Promise<Result<ReturnTypeUnwrapped<typeof getUser>, unknown>>;
+    getUser: (userId: string, email: string) => Promise<Result<ReturnTypeUnwrapped<typeof getUser>, UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/005-zod-schema/expected/register/handlers.ts
+++ b/test/fixture/005-zod-schema/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { createUser } from "../../../fixture/005-zod-schema/input/apis/sample.js";
 
@@ -12,7 +12,7 @@ export const autoGenerateHandlers = {
                 const result = await createUser({ ...ctx, event }, args);
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },

--- a/test/fixture/005-zod-schema/expected/renderer/api.ts
+++ b/test/fixture/005-zod-schema/expected/renderer/api.ts
@@ -1,6 +1,6 @@
 // auto generated
 import type { createUser } from "../../../fixture/005-zod-schema/input/apis/sample.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -13,14 +13,14 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
 declare global {
     interface Window {
         api: {
-            createUser: (username: string, email: string, age: number) => Promise<Result<ReturnTypeUnwrapped<typeof createUser>, unknown>>;
+            createUser: (username: string, email: string, age: number) => Promise<Result<ReturnTypeUnwrapped<typeof createUser>, UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    createUser: (username: string, email: string, age: number) => Promise<Result<ReturnTypeUnwrapped<typeof createUser>, unknown>>;
+    createUser: (username: string, email: string, age: number) => Promise<Result<ReturnTypeUnwrapped<typeof createUser>, UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/006-optional-props/expected/register/handlers.ts
+++ b/test/fixture/006-optional-props/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { updateItem } from "../../../fixture/006-optional-props/input/apis/sample.js";
 
@@ -12,7 +12,7 @@ export const autoGenerateHandlers = {
                 const result = await updateItem({ ...ctx, event }, args);
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },

--- a/test/fixture/006-optional-props/expected/renderer/api.ts
+++ b/test/fixture/006-optional-props/expected/renderer/api.ts
@@ -1,6 +1,6 @@
 // auto generated
 import type { updateItem } from "../../../fixture/006-optional-props/input/apis/sample.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -13,14 +13,14 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
 declare global {
     interface Window {
         api: {
-            updateItem: (id: string, name: string | undefined, description: string | undefined) => Promise<Result<ReturnTypeUnwrapped<typeof updateItem>, unknown>>;
+            updateItem: (id: string, name: string | undefined, description: string | undefined) => Promise<Result<ReturnTypeUnwrapped<typeof updateItem>, UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    updateItem: (id: string, name: string | undefined, description: string | undefined) => Promise<Result<ReturnTypeUnwrapped<typeof updateItem>, unknown>>;
+    updateItem: (id: string, name: string | undefined, description: string | undefined) => Promise<Result<ReturnTypeUnwrapped<typeof updateItem>, UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/007-multiple-files/expected/register/handlers.ts
+++ b/test/fixture/007-multiple-files/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { alpha, beta } from "../../../fixture/007-multiple-files/input/apis/file1.js";
 import { gamma } from "../../../fixture/007-multiple-files/input/apis/file2.js";
@@ -13,7 +13,7 @@ export const autoGenerateHandlers = {
                 const result = await alpha({ ...ctx, event });
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },
@@ -23,7 +23,7 @@ export const autoGenerateHandlers = {
                 const result = await beta({ ...ctx, event }, args);
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },
@@ -33,7 +33,7 @@ export const autoGenerateHandlers = {
                 const result = await gamma({ ...ctx, event }, args);
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },

--- a/test/fixture/007-multiple-files/expected/renderer/api.ts
+++ b/test/fixture/007-multiple-files/expected/renderer/api.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { alpha, beta } from "../../../fixture/007-multiple-files/input/apis/file1.js";
 import type { gamma } from "../../../fixture/007-multiple-files/input/apis/file2.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -14,18 +14,18 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
 declare global {
     interface Window {
         api: {
-            alpha: () => Promise<Result<ReturnTypeUnwrapped<typeof alpha>, unknown>>;
-            beta: (value: number) => Promise<Result<ReturnTypeUnwrapped<typeof beta>, unknown>>;
-            gamma: (name: string) => Promise<Result<ReturnTypeUnwrapped<typeof gamma>, unknown>>;
+            alpha: () => Promise<Result<ReturnTypeUnwrapped<typeof alpha>, UnknownError>>;
+            beta: (value: number) => Promise<Result<ReturnTypeUnwrapped<typeof beta>, UnknownError>>;
+            gamma: (name: string) => Promise<Result<ReturnTypeUnwrapped<typeof gamma>, UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    alpha: () => Promise<Result<ReturnTypeUnwrapped<typeof alpha>, unknown>>;
-    beta: (value: number) => Promise<Result<ReturnTypeUnwrapped<typeof beta>, unknown>>;
-    gamma: (name: string) => Promise<Result<ReturnTypeUnwrapped<typeof gamma>, unknown>>;
+    alpha: () => Promise<Result<ReturnTypeUnwrapped<typeof alpha>, UnknownError>>;
+    beta: (value: number) => Promise<Result<ReturnTypeUnwrapped<typeof beta>, UnknownError>>;
+    gamma: (name: string) => Promise<Result<ReturnTypeUnwrapped<typeof gamma>, UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/008-custom-error-handler/expected/register/handlers.ts
+++ b/test/fixture/008-custom-error-handler/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 import { handleError } from "../../../fixture/_shared/error-handler.js";
 
 import { processData } from "../../../fixture/008-custom-error-handler/input/apis/sample.js";
@@ -16,7 +16,7 @@ export const autoGenerateHandlers = {
                 try {
                     return failure(handleError(e, { ...ctx, event }));
                 } catch (handlerError) {
-                    return failure(e);
+                    return failure(unknownError(e));
                 }
             }
         };

--- a/test/fixture/008-custom-error-handler/expected/register/handlers.ts
+++ b/test/fixture/008-custom-error-handler/expected/register/handlers.ts
@@ -13,7 +13,11 @@ export const autoGenerateHandlers = {
                 const result = await processData({ ...ctx, event }, args);
                 return success(result);
             } catch (e) {
-                return handleError(e, { ...ctx, event });
+                try {
+                    return failure(handleError(e, { ...ctx, event }));
+                } catch (handlerError) {
+                    return failure(e);
+                }
             }
         };
     },

--- a/test/fixture/008-custom-error-handler/expected/renderer/api.ts
+++ b/test/fixture/008-custom-error-handler/expected/renderer/api.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { processData } from "../../../fixture/008-custom-error-handler/input/apis/sample.js";
 import type { handleError } from "../../../fixture/_shared/error-handler.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -16,14 +16,14 @@ type GlobalErrorType = ReturnType<typeof handleError>;
 declare global {
     interface Window {
         api: {
-            processData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof processData>, GlobalErrorType>>;
+            processData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof processData>, GlobalErrorType | UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    processData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof processData>, GlobalErrorType>>;
+    processData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof processData>, GlobalErrorType | UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/009-ignores/expected/register/handlers.ts
+++ b/test/fixture/009-ignores/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { included } from "../../../fixture/009-ignores/input/apis/sample.js";
 
@@ -12,7 +12,7 @@ export const autoGenerateHandlers = {
                 const result = await included({ ...ctx, event });
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },

--- a/test/fixture/009-ignores/expected/renderer/api.ts
+++ b/test/fixture/009-ignores/expected/renderer/api.ts
@@ -1,6 +1,6 @@
 // auto generated
 import type { included } from "../../../fixture/009-ignores/input/apis/sample.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -13,14 +13,14 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
 declare global {
     interface Window {
         api: {
-            included: () => Promise<Result<ReturnTypeUnwrapped<typeof included>, unknown>>;
+            included: () => Promise<Result<ReturnTypeUnwrapped<typeof included>, UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    included: () => Promise<Result<ReturnTypeUnwrapped<typeof included>, unknown>>;
+    included: () => Promise<Result<ReturnTypeUnwrapped<typeof included>, UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/010-validator-config/expected/register/handlers.ts
+++ b/test/fixture/010-validator-config/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { createItem, validateCreateItem } from "../../../fixture/010-validator-config/input/apis/sample.js";
 
@@ -13,7 +13,7 @@ export const autoGenerateHandlers = {
                 const result = await createItem({ ...ctx, event }, validatedArgs);
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },

--- a/test/fixture/010-validator-config/expected/renderer/api.ts
+++ b/test/fixture/010-validator-config/expected/renderer/api.ts
@@ -1,6 +1,6 @@
 // auto generated
 import type { createItem } from "../../../fixture/010-validator-config/input/apis/sample.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -13,14 +13,14 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
 declare global {
     interface Window {
         api: {
-            createItem: (name: string, price: number) => Promise<Result<ReturnTypeUnwrapped<typeof createItem>, unknown>>;
+            createItem: (name: string, price: number) => Promise<Result<ReturnTypeUnwrapped<typeof createItem>, UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    createItem: (name: string, price: number) => Promise<Result<ReturnTypeUnwrapped<typeof createItem>, unknown>>;
+    createItem: (name: string, price: number) => Promise<Result<ReturnTypeUnwrapped<typeof createItem>, UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/011-error-handler-config/expected/register/handlers.ts
+++ b/test/fixture/011-error-handler-config/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { saveData, saveDataErrorHandler } from "../../../fixture/011-error-handler-config/input/apis/sample.js";
 
@@ -17,9 +17,9 @@ export const autoGenerateHandlers = {
                     if (individualResult !== null) {
                         return failure(individualResult);
                     }
-                    return failure(e);
+                    return failure(unknownError(e));
                 } catch (handlerError) {
-                    return failure(e);
+                    return failure(unknownError(e));
                 }
             }
         };

--- a/test/fixture/011-error-handler-config/expected/renderer/api.ts
+++ b/test/fixture/011-error-handler-config/expected/renderer/api.ts
@@ -1,6 +1,6 @@
 // auto generated
 import type { saveData, saveDataErrorHandler } from "../../../fixture/011-error-handler-config/input/apis/sample.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -14,14 +14,14 @@ type SaveDataErrorType = NonNullable<ReturnType<typeof saveDataErrorHandler>>;
 declare global {
     interface Window {
         api: {
-            saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | unknown>>;
+            saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | unknown>>;
+    saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/011-error-handler-config/expected/renderer/api.ts
+++ b/test/fixture/011-error-handler-config/expected/renderer/api.ts
@@ -1,5 +1,5 @@
 // auto generated
-import type { saveData } from "../../../fixture/011-error-handler-config/input/apis/sample.js";
+import type { saveData, saveDataErrorHandler } from "../../../fixture/011-error-handler-config/input/apis/sample.js";
 import type { Result } from "electron-flow";
 
 // Promise を外す型ユーティリティ
@@ -8,19 +8,20 @@ type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
 type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
     ? UnwrapPromise<R>
     : never;
+type SaveDataErrorType = NonNullable<ReturnType<typeof saveDataErrorHandler>>;
 
 // window.api の型定義
 declare global {
     interface Window {
         api: {
-            saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, unknown>>;
+            saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | unknown>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, unknown>>;
+    saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | unknown>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/012-validator-and-error-handler/expected/register/handlers.ts
+++ b/test/fixture/012-validator-and-error-handler/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { updateRecord, validateUpdateRecord, updateRecordErrorHandler } from "../../../fixture/012-validator-and-error-handler/input/apis/sample.js";
 
@@ -18,9 +18,9 @@ export const autoGenerateHandlers = {
                     if (individualResult !== null) {
                         return failure(individualResult);
                     }
-                    return failure(e);
+                    return failure(unknownError(e));
                 } catch (handlerError) {
-                    return failure(e);
+                    return failure(unknownError(e));
                 }
             }
         };

--- a/test/fixture/012-validator-and-error-handler/expected/register/handlers.ts
+++ b/test/fixture/012-validator-and-error-handler/expected/register/handlers.ts
@@ -13,11 +13,15 @@ export const autoGenerateHandlers = {
                 const result = await updateRecord({ ...ctx, event }, validatedArgs);
                 return success(result);
             } catch (e) {
-                const individualResult = updateRecordErrorHandler(e, { ...ctx, event });
-                if (individualResult !== null) {
-                    return failure(individualResult);
+                try {
+                    const individualResult = updateRecordErrorHandler(e, { ...ctx, event });
+                    if (individualResult !== null) {
+                        return failure(individualResult);
+                    }
+                    return failure(e);
+                } catch (handlerError) {
+                    return failure(e);
                 }
-                return failure(e);
             }
         };
     },

--- a/test/fixture/012-validator-and-error-handler/expected/renderer/api.ts
+++ b/test/fixture/012-validator-and-error-handler/expected/renderer/api.ts
@@ -1,6 +1,6 @@
 // auto generated
 import type { updateRecord, updateRecordErrorHandler } from "../../../fixture/012-validator-and-error-handler/input/apis/sample.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -14,14 +14,14 @@ type UpdateRecordErrorType = NonNullable<ReturnType<typeof updateRecordErrorHand
 declare global {
     interface Window {
         api: {
-            updateRecord: (id: string, value: number) => Promise<Result<ReturnTypeUnwrapped<typeof updateRecord>, UpdateRecordErrorType | unknown>>;
+            updateRecord: (id: string, value: number) => Promise<Result<ReturnTypeUnwrapped<typeof updateRecord>, UpdateRecordErrorType | UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    updateRecord: (id: string, value: number) => Promise<Result<ReturnTypeUnwrapped<typeof updateRecord>, UpdateRecordErrorType | unknown>>;
+    updateRecord: (id: string, value: number) => Promise<Result<ReturnTypeUnwrapped<typeof updateRecord>, UpdateRecordErrorType | UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/012-validator-and-error-handler/expected/renderer/api.ts
+++ b/test/fixture/012-validator-and-error-handler/expected/renderer/api.ts
@@ -1,5 +1,5 @@
 // auto generated
-import type { updateRecord } from "../../../fixture/012-validator-and-error-handler/input/apis/sample.js";
+import type { updateRecord, updateRecordErrorHandler } from "../../../fixture/012-validator-and-error-handler/input/apis/sample.js";
 import type { Result } from "electron-flow";
 
 // Promise を外す型ユーティリティ
@@ -8,19 +8,20 @@ type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
 type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
     ? UnwrapPromise<R>
     : never;
+type UpdateRecordErrorType = NonNullable<ReturnType<typeof updateRecordErrorHandler>>;
 
 // window.api の型定義
 declare global {
     interface Window {
         api: {
-            updateRecord: (id: string, value: number) => Promise<Result<ReturnTypeUnwrapped<typeof updateRecord>, unknown>>;
+            updateRecord: (id: string, value: number) => Promise<Result<ReturnTypeUnwrapped<typeof updateRecord>, UpdateRecordErrorType | unknown>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    updateRecord: (id: string, value: number) => Promise<Result<ReturnTypeUnwrapped<typeof updateRecord>, unknown>>;
+    updateRecord: (id: string, value: number) => Promise<Result<ReturnTypeUnwrapped<typeof updateRecord>, UpdateRecordErrorType | unknown>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/013-events/expected/register/handlers.ts
+++ b/test/fixture/013-events/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 
 import { ping } from "../../../fixture/013-events/input/apis/sample.js";
 
@@ -12,7 +12,7 @@ export const autoGenerateHandlers = {
                 const result = await ping({ ...ctx, event });
                 return success(result);
             } catch (e) {
-                return failure(e);
+                return failure(unknownError(e));
             }
         };
     },

--- a/test/fixture/013-events/expected/renderer/api.ts
+++ b/test/fixture/013-events/expected/renderer/api.ts
@@ -1,6 +1,6 @@
 // auto generated
 import type { ping } from "../../../fixture/013-events/input/apis/sample.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -13,14 +13,14 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
 declare global {
     interface Window {
         api: {
-            ping: () => Promise<Result<ReturnTypeUnwrapped<typeof ping>, unknown>>;
+            ping: () => Promise<Result<ReturnTypeUnwrapped<typeof ping>, UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    ping: () => Promise<Result<ReturnTypeUnwrapped<typeof ping>, unknown>>;
+    ping: () => Promise<Result<ReturnTypeUnwrapped<typeof ping>, UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/014-custom-and-individual-error-handler/config.ts
+++ b/test/fixture/014-custom-and-individual-error-handler/config.ts
@@ -1,0 +1,27 @@
+import type { BuildTestCase } from "../../types.js";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const config: BuildTestCase = {
+	name: "customAndIndividualErrorHandler",
+	options: {
+		customErrorHandler: {
+			path: join(__dirname, "../_shared/error-handler.ts"),
+			functionName: "handleError",
+		},
+		errorHandlerConfig: {
+			pattern: "{funcName}ErrorHandler",
+		},
+	},
+	expectedFiles: [
+		"register/handlers.ts",
+		"register/api.ts",
+		"preload/api.ts",
+		"renderer/api.ts",
+	],
+};
+
+export default config;

--- a/test/fixture/014-custom-and-individual-error-handler/expected/preload/api.ts
+++ b/test/fixture/014-custom-and-individual-error-handler/expected/preload/api.ts
@@ -1,0 +1,7 @@
+// auto generated
+import { ipcRenderer } from "electron";
+
+export default {
+    processData: (data: string) => ipcRenderer.invoke("processData", { data }),
+    saveData: (data: string) => ipcRenderer.invoke("saveData", { data })
+};

--- a/test/fixture/014-custom-and-individual-error-handler/expected/register/api.ts
+++ b/test/fixture/014-custom-and-individual-error-handler/expected/register/api.ts
@@ -1,0 +1,16 @@
+// auto generated
+import type { Context } from "../../../fixture/_shared/context.js";
+import { ipcMain } from "electron";
+import { autoGenerateHandlers } from "./handlers.js";
+
+export function registerAutoGenerateAPI(ctx: Omit<Context, "event">) {
+    Object.entries(autoGenerateHandlers).forEach(([key, value]) => {
+        ipcMain.handle(key, value(ctx));
+    });
+}
+
+export function removeAutoGenerateAPI() {
+    Object.keys(autoGenerateHandlers).forEach(key => {
+        ipcMain.removeHandler(key);
+    });
+}

--- a/test/fixture/014-custom-and-individual-error-handler/expected/register/handlers.ts
+++ b/test/fixture/014-custom-and-individual-error-handler/expected/register/handlers.ts
@@ -2,10 +2,25 @@
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
 import { success, failure } from "electron-flow";
+import { handleError } from "../../../fixture/_shared/error-handler.js";
 
-import { saveData, saveDataErrorHandler } from "../../../fixture/011-error-handler-config/input/apis/sample.js";
+import { processData, saveData, saveDataErrorHandler } from "../../../fixture/014-custom-and-individual-error-handler/input/apis/sample.js";
 
 export const autoGenerateHandlers = {
+    "processData": (ctx: Omit<Context, "event">) => {
+        return async (event: IpcMainInvokeEvent, args: any) => {
+            try {
+                const result = await processData({ ...ctx, event }, args);
+                return success(result);
+            } catch (e) {
+                try {
+                    return failure(handleError(e, { ...ctx, event }));
+                } catch (handlerError) {
+                    return failure(e);
+                }
+            }
+        };
+    },
     "saveData": (ctx: Omit<Context, "event">) => {
         return async (event: IpcMainInvokeEvent, args: any) => {
             try {
@@ -17,7 +32,7 @@ export const autoGenerateHandlers = {
                     if (individualResult !== null) {
                         return failure(individualResult);
                     }
-                    return failure(e);
+                    return failure(handleError(e, { ...ctx, event }));
                 } catch (handlerError) {
                     return failure(e);
                 }

--- a/test/fixture/014-custom-and-individual-error-handler/expected/register/handlers.ts
+++ b/test/fixture/014-custom-and-individual-error-handler/expected/register/handlers.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { Context } from "../../../fixture/_shared/context.js";
 import type { IpcMainInvokeEvent } from "electron";
-import { success, failure } from "electron-flow";
+import { success, failure, unknownError } from "electron-flow";
 import { handleError } from "../../../fixture/_shared/error-handler.js";
 
 import { processData, saveData, saveDataErrorHandler } from "../../../fixture/014-custom-and-individual-error-handler/input/apis/sample.js";
@@ -16,7 +16,7 @@ export const autoGenerateHandlers = {
                 try {
                     return failure(handleError(e, { ...ctx, event }));
                 } catch (handlerError) {
-                    return failure(e);
+                    return failure(unknownError(e));
                 }
             }
         };
@@ -34,7 +34,7 @@ export const autoGenerateHandlers = {
                     }
                     return failure(handleError(e, { ...ctx, event }));
                 } catch (handlerError) {
-                    return failure(e);
+                    return failure(unknownError(e));
                 }
             }
         };

--- a/test/fixture/014-custom-and-individual-error-handler/expected/renderer/api.ts
+++ b/test/fixture/014-custom-and-individual-error-handler/expected/renderer/api.ts
@@ -1,7 +1,7 @@
 // auto generated
 import type { processData, saveData, saveDataErrorHandler } from "../../../fixture/014-custom-and-individual-error-handler/input/apis/sample.js";
 import type { handleError } from "../../../fixture/_shared/error-handler.js";
-import type { Result } from "electron-flow";
+import type { Result, UnknownError } from "electron-flow";
 
 // Promise を外す型ユーティリティ
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -17,16 +17,16 @@ type SaveDataErrorType = NonNullable<ReturnType<typeof saveDataErrorHandler>>;
 declare global {
     interface Window {
         api: {
-            processData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof processData>, GlobalErrorType>>;
-            saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | GlobalErrorType>>;
+            processData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof processData>, GlobalErrorType | UnknownError>>;
+            saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | GlobalErrorType | UnknownError>>;
         };
     }
 }
 
 // サービスインターフェース
 export interface ServiceIF {
-    processData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof processData>, GlobalErrorType>>;
-    saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | GlobalErrorType>>;
+    processData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof processData>, GlobalErrorType | UnknownError>>;
+    saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | GlobalErrorType | UnknownError>>;
 }
 
 // サービス実装クラス

--- a/test/fixture/014-custom-and-individual-error-handler/expected/renderer/api.ts
+++ b/test/fixture/014-custom-and-individual-error-handler/expected/renderer/api.ts
@@ -1,5 +1,5 @@
 // auto generated
-import type { processData } from "../../../fixture/008-custom-error-handler/input/apis/sample.js";
+import type { processData, saveData, saveDataErrorHandler } from "../../../fixture/014-custom-and-individual-error-handler/input/apis/sample.js";
 import type { handleError } from "../../../fixture/_shared/error-handler.js";
 import type { Result } from "electron-flow";
 
@@ -11,12 +11,14 @@ type ReturnTypeUnwrapped<T> = T extends (...args: infer _Args) => infer R
     : never;
 // グローバルエラーハンドラーの型（生の値を返す）
 type GlobalErrorType = ReturnType<typeof handleError>;
+type SaveDataErrorType = NonNullable<ReturnType<typeof saveDataErrorHandler>>;
 
 // window.api の型定義
 declare global {
     interface Window {
         api: {
             processData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof processData>, GlobalErrorType>>;
+            saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | GlobalErrorType>>;
         };
     }
 }
@@ -24,11 +26,16 @@ declare global {
 // サービスインターフェース
 export interface ServiceIF {
     processData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof processData>, GlobalErrorType>>;
+    saveData: (data: string) => Promise<Result<ReturnTypeUnwrapped<typeof saveData>, SaveDataErrorType | GlobalErrorType>>;
 }
 
 // サービス実装クラス
 export class ApiService implements ServiceIF {
     async processData(data: string) {
         return window.api.processData(data);
+    }
+
+    async saveData(data: string) {
+        return window.api.saveData(data);
     }
 }

--- a/test/fixture/014-custom-and-individual-error-handler/input/apis/sample.ts
+++ b/test/fixture/014-custom-and-individual-error-handler/input/apis/sample.ts
@@ -1,0 +1,32 @@
+import type { Context } from "../../../_shared/context.js";
+
+interface ValidationError {
+	field: string;
+	reason: string;
+}
+
+// 個別エラーハンドラーあり
+export function saveDataErrorHandler(
+	error: unknown,
+	_ctx: Context & { event: unknown },
+): ValidationError | null {
+	if (error instanceof Error && error.message.includes("validation")) {
+		return { field: "data", reason: error.message };
+	}
+	return null; // カスタムエラーハンドラーにフォールバック
+}
+
+export async function saveData(
+	ctx: Context,
+	req: { data: string },
+): Promise<{ saved: boolean }> {
+	return { saved: true };
+}
+
+// 個別エラーハンドラーなし（カスタムエラーハンドラーのみ使用）
+export async function processData(
+	ctx: Context,
+	req: { data: string },
+): Promise<{ processed: boolean }> {
+	return { processed: true };
+}

--- a/test/fixture/_shared/error-handler.ts
+++ b/test/fixture/_shared/error-handler.ts
@@ -1,5 +1,4 @@
 import type { Context } from "./context.js";
-import type { Failure } from "../../src/result.js";
 
 export interface AppError {
 	code: string;
@@ -8,13 +7,10 @@ export interface AppError {
 
 export function handleError(
 	error: unknown,
-	ctx: Context & { event: unknown },
-): Failure<AppError> {
+	_ctx: Context & { event: unknown },
+): AppError {
 	return {
-		_tag: "failure",
-		value: {
-			code: "UNKNOWN_ERROR",
-			message: error instanceof Error ? error.message : "Unknown error",
-		},
+		code: "UNKNOWN_ERROR",
+		message: error instanceof Error ? error.message : "Unknown error",
 	};
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * カスタム／グローバルのエラーハンドラーに任意の debug フラグを追加し、ハンドラー失敗時の console.warn 出力を制御可能に

* **Bug Fixes**
  * すべてのエラーハンドラー呼び出しを安全に try-catch で保護
  * ハンドラーが null/失敗した際のフォールバック動作を明確化し、UnknownError による標準化された失敗結果を導入
  * 個別ハンドラーとグローバルハンドラーの組み合わせ時の一貫した振る舞いを改善

* **Tests**
  * カスタム＋個別エラーハンドラー動作を検証するテストケースを追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->